### PR TITLE
[Feat] 온보딩 페이지 태그/조합/완료 API

### DIFF
--- a/devicelife-api/build.gradle
+++ b/devicelife-api/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
@@ -34,8 +34,9 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	//testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15"
 }
 
 tasks.named('test') {

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/response/SuccessCode.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/response/SuccessCode.java
@@ -18,11 +18,15 @@ public enum SuccessCode {
     DEVICE_2001("DEVICE_2001", "디바이스 목록 조회에 성공했습니다."),
     DEVICE_2002("DEVICE_2002", "디바이스 상세 조회에 성공했습니다."),
 
-    // 예시: 콤보
-    COMBO_2001("COMBO_2001", "콤보 생성에 성공했습니다."),
-    COMBO_2002("COMBO_2002", "콤보 조회에 성공했습니다."),
-    COMBO_2003("COMBO_2003", "콤보 수정에 성공했습니다."),
-    COMBO_2004("COMBO_2004", "콤보 삭제에 성공했습니다.");
+    COMBO_CREATE_SUCCESS("COMBO_2000", "조합 생성에 성공했습니다."),
+
+    TAG_GET_SUCCESS("TAG_2000", "태그 목록 조회에 성공했습니다."),
+    TAG_SAVE_SUCCESS("TAG_2001", "유저 태그 저장에 성공했습니다."),
+
+    ONBOARDING_COMPLETE_SUCCESS("ONBOARDING_2000", "온보딩 완료 처리에 성공했습니다."),
+
+    LIFESTYLE_GET_SUCCESS("LIFESTYLE_2000", "라이프스타일 추천 조회에 성공했습니다.");
+
 
     private final String code;
     private final String message;

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/combo/ComboController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/combo/ComboController.java
@@ -1,0 +1,77 @@
+package com.devicelife.devicelife_api.controller.combo;
+
+import com.devicelife.devicelife_api.common.response.ApiResponse;
+import com.devicelife.devicelife_api.common.response.SuccessCode;
+import com.devicelife.devicelife_api.domain.combo.dto.request.ComboCreateRequestDto;
+import com.devicelife.devicelife_api.domain.combo.dto.response.ComboCreateResponseDto;
+import com.devicelife.devicelife_api.service.combo.ComboService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Combo",
+        description = """
+        온보딩 '조합 생성하기' 화면에서 조합명(comboName)을 저장하는 API.
+        """
+)
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/combos")
+public class ComboController {
+
+    private final ComboService comboService;
+
+    @Operation(
+            summary = "조합 생성",
+            description = """
+            comboName을 받아 combos 테이블에 조합을 생성한다.
+
+            [JWT 전환 예정]
+            - 현재: userId를 요청 바디로 받음
+            - 추후: JWT 인증 도입 시 userId는 토큰에서 추출하도록 변경
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 (ApiResponse.result에 comboId, comboName 반환)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 userId",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<ComboCreateResponseDto>> createCombo(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = """
+                    - userId: 임시(인증 도입 후 토큰에서 추출하도록 변경)
+                    - comboName: 최대 80자(Combo 엔티티 제약)
+                    """,
+                    content = @Content(schema = @Schema(implementation = ComboCreateRequestDto.class))
+            )
+            @Valid @RequestBody ComboCreateRequestDto request) {
+        ComboCreateResponseDto result = comboService.createCombo(request);
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        SuccessCode.COMBO_CREATE_SUCCESS.getCode(),
+                        SuccessCode.COMBO_CREATE_SUCCESS.getMessage(),
+                        result
+                )
+        );
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/onboarding/OnboardingController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/onboarding/OnboardingController.java
@@ -1,0 +1,72 @@
+package com.devicelife.devicelife_api.controller.onboarding;
+
+import com.devicelife.devicelife_api.common.response.ApiResponse;
+import com.devicelife.devicelife_api.common.response.SuccessCode;
+import com.devicelife.devicelife_api.domain.onboarding.dto.request.OnboardingCompleteRequestDto;
+import com.devicelife.devicelife_api.service.onboarding.OnboardingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Onboarding",
+        description = """
+        온보딩 완료 처리 API.
+        """
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/onboarding")
+public class OnboardingController {
+
+    private final OnboardingService onboardingService;
+
+    @Operation(
+            summary = "온보딩 완료 처리",
+            description = """
+            users.onboardingCompleted를 true로 설정한다.
+
+            [JWT 전환 예정]
+            - 현재: userId를 요청 바디로 받음
+            - 추후: JWT 인증 도입 시 userId는 토큰에서 추출하도록 변경
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 (ApiResponse.result = null)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 userId",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    @PostMapping("/complete")
+    public ResponseEntity<ApiResponse<Void>> complete(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "userId는 임시(인증 도입 후 토큰에서 추출하도록 변경).",
+                    content = @Content(schema = @Schema(implementation = OnboardingCompleteRequestDto.class))
+            )
+            @Valid @RequestBody OnboardingCompleteRequestDto request) {
+        onboardingService.complete(request);
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        SuccessCode.ONBOARDING_COMPLETE_SUCCESS.getCode(),
+                        SuccessCode.ONBOARDING_COMPLETE_SUCCESS.getMessage(),
+                        null
+                )
+        );
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/tag/TagController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/tag/TagController.java
@@ -1,0 +1,115 @@
+package com.devicelife.devicelife_api.controller.tag;
+
+import com.devicelife.devicelife_api.common.response.ApiResponse;
+import com.devicelife.devicelife_api.common.response.SuccessCode;
+import com.devicelife.devicelife_api.domain.device.dto.request.UserTagRequestDto;
+import com.devicelife.devicelife_api.domain.device.dto.response.TagResponseDto;
+import com.devicelife.devicelife_api.service.tag.TagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(
+        name = "Tag",
+        description = """
+        온보딩(관심사/라이프스타일/브랜드) 및 라이프스타일 화면에서 사용하는 태그 API.
+        """
+)
+
+@RestController
+@RequestMapping("/api/tags")
+@RequiredArgsConstructor
+public class TagController {
+
+    private final TagService tagService;
+
+    @Operation(
+            summary = "태그 목록 조회",
+            description = """
+            type으로 필터링해서 태그를 조회한다.
+
+            - type 미지정: 전체 태그
+            - type 지정: 해당 tagType만 조회 (예: INTEREST, LIFESTYLE, BRAND)
+
+            [프론트 참고]
+            - 화면 좌측 태그 버튼 렌더링에 사용.
+            - type 값은 대소문자 섞여 와도 서버에서 upper-case normalize 처리.
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 (ApiResponse.result에 TagResponseDto 리스트 반환)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TagResponseDto>>> getTags(
+            @Parameter(
+                    description = "태그 타입 필터. 없으면 전체 조회. (예: INTEREST, LIFESTYLE, BRAND)",
+                    example = "LIFESTYLE",
+                    required = false
+            )
+            @RequestParam(value = "type", required = false) String type
+    ) {
+        List<TagResponseDto> result = tagService.getTags(type);
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        SuccessCode.TAG_GET_SUCCESS.getCode(),
+                        SuccessCode.TAG_GET_SUCCESS.getMessage(),
+                        result
+                )
+        );
+    }
+    @Operation(
+            summary = "유저 선택 태그 저장 (replace)",
+            description = """
+            유저가 선택한 tagIds를 userTags에 저장한다.
+
+            [중요: replace(덮어쓰기) 동작]
+            - 요청으로 들어온 tagIds를 조회해서, 그 태그들이 속한 tagType(들)을 구함
+            - 해당 tagType(들)에 해당하는 기존 userTags를 삭제
+            - 이번 요청의 tagIds를 다시 저장
+
+            [왜 replace?]
+            - 온보딩/선택 UI에서 유저가 선택을 바꾸는 게 자연스러움.
+              add-only(추가만)로 저장하면 사용자가 '해제'한 태그가 DB에 남아 데이터가 망가짐.
+
+            [JWT 전환 예정]
+            - 현재는 userId를 바디로 받음(임시).
+            - JWT 적용 후에는 userId를 토큰에서 추출하도록 바꿀 것.
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 (ApiResponse.result = null)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "userId 또는 tagIds 중 존재하지 않는 값 포함",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    @PostMapping("/user")
+    public ResponseEntity<ApiResponse<Void>> saveUserTags(@Valid @RequestBody UserTagRequestDto request) {
+        tagService.saveUserTags(request);
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        SuccessCode.TAG_SAVE_SUCCESS.getCode(),
+                        SuccessCode.TAG_SAVE_SUCCESS.getMessage(),
+                        null
+                )
+        );
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/combo/dto/request/ComboCreateRequestDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/combo/dto/request/ComboCreateRequestDto.java
@@ -1,0 +1,17 @@
+package com.devicelife.devicelife_api.domain.combo.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ComboCreateRequestDto {
+
+    @NotNull
+    private Long userId;
+
+    @NotBlank
+    @Size(max = 80)
+    private String comboName;
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/combo/dto/response/ComboCreateResponseDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/combo/dto/response/ComboCreateResponseDto.java
@@ -1,0 +1,11 @@
+package com.devicelife.devicelife_api.domain.combo.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ComboCreateResponseDto {
+    private Long comboId;
+    private String comboName;
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/device/dto/request/UserTagRequestDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/device/dto/request/UserTagRequestDto.java
@@ -1,0 +1,17 @@
+package com.devicelife.devicelife_api.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UserTagRequestDto {
+
+    @NotNull
+    private Long userId;
+
+    @NotEmpty
+    private List<Long> tagIds;
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/device/dto/response/TagResponseDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/device/dto/response/TagResponseDto.java
@@ -1,0 +1,24 @@
+package com.devicelife.devicelife_api.domain.device.dto.response;
+
+import com.devicelife.devicelife_api.domain.device.Tag;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TagResponseDto {
+    private Long tagId;
+    private String tagKey;    // 예: interest_game
+    private String tagLabel;  // 예: 게임
+    private String tagType;   // 예: INTEREST
+
+    // Entity -> DTO 변환 메서드
+    public static TagResponseDto from(Tag tag) {
+        return TagResponseDto.builder()
+                .tagId(tag.getTagId())
+                .tagKey(tag.getTagKey())
+                .tagLabel(tag.getTagLabel())
+                .tagType(tag.getTagType())
+                .build();
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/onboarding/dto/request/OnboardingCompleteRequestDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/onboarding/dto/request/OnboardingCompleteRequestDto.java
@@ -1,0 +1,11 @@
+package com.devicelife.devicelife_api.domain.onboarding.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class OnboardingCompleteRequestDto {
+
+    @NotNull
+    private Long userId;
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/combo/ComboRepository.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/combo/ComboRepository.java
@@ -1,0 +1,7 @@
+package com.devicelife.devicelife_api.repository.combo;
+
+import com.devicelife.devicelife_api.domain.combo.Combo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ComboRepository extends JpaRepository<Combo, Long> {
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/tag/TagRepository.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/tag/TagRepository.java
@@ -1,0 +1,17 @@
+package com.devicelife.devicelife_api.repository.tag;
+
+import com.devicelife.devicelife_api.domain.device.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    /**
+     * tagType 컬럼을 기준으로 태그를 조회합니다.
+     * 예: findAllByTagType("LIFESTYLE") -> 라이프스타일 태그만 반환
+     */
+    List<Tag> findAllByTagType(String tagType);
+    Optional<Tag> findByTagKey(String tagKey);
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/tag/UserTagRepository.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/tag/UserTagRepository.java
@@ -1,0 +1,26 @@
+package com.devicelife.devicelife_api.repository.tag;
+
+import com.devicelife.devicelife_api.domain.user.UserTag;
+import com.devicelife.devicelife_api.domain.user.UserTagId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+public interface UserTagRepository extends JpaRepository<UserTag, UserTagId> {
+    List<UserTag> findAllById_UserId(Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        delete from UserTag ut
+        where ut.id.userId = :userId
+          and ut.tag.tagType in :tagTypes
+    """)
+    void deleteByUserIdAndTagTypes(
+            @Param("userId") Long userId,
+            @Param("tagTypes") Set<String> tagTypes
+    );
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/combo/ComboService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/combo/ComboService.java
@@ -1,0 +1,42 @@
+package com.devicelife.devicelife_api.service.combo;
+
+import com.devicelife.devicelife_api.domain.combo.Combo;
+import com.devicelife.devicelife_api.domain.combo.dto.request.ComboCreateRequestDto;
+import com.devicelife.devicelife_api.domain.combo.dto.response.ComboCreateResponseDto;
+import com.devicelife.devicelife_api.domain.user.User;
+import com.devicelife.devicelife_api.repository.combo.ComboRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ComboService {
+
+    private final ComboRepository comboRepository;
+    private final EntityManager em;
+
+    @Transactional
+    public ComboCreateResponseDto createCombo(ComboCreateRequestDto request) {
+        Long userId = request.getUserId();
+
+        User user = em.find(User.class, userId);
+        if (user == null) {
+            throw new EntityNotFoundException("존재하지 않는 userId: " + userId);
+        }
+
+        Combo combo = Combo.builder()
+                .user(user)
+                .comboName(request.getComboName())
+                .build();
+
+        Combo saved = comboRepository.save(combo);
+
+        return ComboCreateResponseDto.builder()
+                .comboId(saved.getComboId())
+                .comboName(saved.getComboName())
+                .build();
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/onboarding/OnboardingService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/onboarding/OnboardingService.java
@@ -1,0 +1,30 @@
+package com.devicelife.devicelife_api.service.onboarding;
+
+import com.devicelife.devicelife_api.domain.onboarding.dto.request.OnboardingCompleteRequestDto;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OnboardingService {
+
+    private final EntityManager em;
+
+    @Transactional
+    public void complete(OnboardingCompleteRequestDto request) {
+        Long userId = request.getUserId();
+
+        int updated = em.createQuery(
+                        "update User u set u.onboardingCompleted = true where u.userId = :userId"
+                )
+                .setParameter("userId", userId)
+                .executeUpdate();
+
+        if (updated == 0) {
+            throw new EntityNotFoundException("존재하지 않는 userId: " + userId);
+        }
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/tag/TagService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/tag/TagService.java
@@ -1,0 +1,88 @@
+package com.devicelife.devicelife_api.service.tag;
+
+import com.devicelife.devicelife_api.domain.device.Tag;
+import com.devicelife.devicelife_api.domain.device.dto.request.UserTagRequestDto;
+import com.devicelife.devicelife_api.domain.device.dto.response.TagResponseDto;
+import com.devicelife.devicelife_api.domain.user.User;
+import com.devicelife.devicelife_api.domain.user.UserTag;
+import com.devicelife.devicelife_api.domain.user.UserTagId;
+import com.devicelife.devicelife_api.repository.tag.TagRepository;
+import com.devicelife.devicelife_api.repository.tag.UserTagRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+    private final TagRepository tagRepository;
+    private final UserTagRepository userTagRepository;
+    private final EntityManager em;
+
+    @Transactional(readOnly = true)
+    public List<TagResponseDto> getTags(String type) {
+        List<Tag> tags;
+
+        if (!StringUtils.hasText(type)) {
+            tags = tagRepository.findAll();
+        } else {
+            String normalized = type.trim().toUpperCase();
+            tags = tagRepository.findAllByTagType(normalized);
+        }
+
+        return tags.stream().map(TagResponseDto::from).toList();
+    }
+
+    @Transactional
+    public void saveUserTags(UserTagRequestDto request) {
+        Long userId = request.getUserId();
+
+        User user = em.find(User.class, userId);
+        if (user == null) {
+            throw new EntityNotFoundException("존재하지 않는 userId: " + userId);
+        }
+
+        List<Long> tagIds = request.getTagIds().stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        List<Tag> tags = tagRepository.findAllById(tagIds);
+
+        if (tags.size() != tagIds.size()) {
+            Set<Long> found = tags.stream().map(Tag::getTagId).collect(Collectors.toSet());
+            List<Long> missing = tagIds.stream().filter(id -> !found.contains(id)).toList();
+            throw new EntityNotFoundException("존재하지 않는 tagIds: " + missing);
+        }
+
+        // replace 기준: 이번 요청에 포함된 tagType들을 추출
+        Set<String> tagTypes = tags.stream()
+                .map(t -> t.getTagType().trim().toUpperCase())
+                .collect(Collectors.toSet());
+
+        // 해당 tagType 영역은 기존 선택 싹 삭제
+        userTagRepository.deleteByUserIdAndTagTypes(userId, tagTypes);
+
+        // 새로 저장
+        List<UserTag> toSave = tags.stream()
+                .map(t -> UserTag.builder()
+                        .id(new UserTagId(userId, t.getTagId()))
+                        .user(user)
+                        .tag(t)
+                        .build()
+                )
+                .toList();
+
+        userTagRepository.saveAll(toSave);
+    }
+
+}


### PR DESCRIPTION
## 변경 내용 요약

온보딩 플로우에서 필요한 **태그 조회/유저 태그 저장(replace)/조합 생성/온보딩 완료 처리** API를 구현했고, Swagger 명세까지 붙였습니다.
라이프스타일 “추천 카드” 쪽은 프론트 하드코딩 방침이라 **백엔드 로직/API는 제거**하고 태그 API로만 지원합니다..

---

## 구현한 API

### Tag

* **GET** `/api/tags?type={INTEREST|LIFESTYLE|BRAND}`

  * 온보딩(관심사/라이프스타일/브랜드) 화면에서 버튼(태그) 리스트 조회
  * `type` 없으면 전체 조회

* **POST** `/api/tags/user` *(replace)*

  * 유저가 선택한 태그 저장
  * `type` 단위로 **기존 선택값 삭제 후** 요청으로 들어온 목록으로 **덮어쓰기(replace)**

### Combo

* **POST** `/api/combos`

  * 온보딩 “조합 생성하기” 화면에서 `comboName` 저장

### Onboarding

* **POST** `/api/onboarding/complete`

  * 온보딩 완료 처리 (`users.onboardingCompleted = true`)

---

## 특이사항

* **userId를 Body로 받는 구조는 임시**

  * 로그인/JWT 붙으면 `userId`는 **토큰에서 추출**하는 방식으로 바꿔야 합니다. @nsh0919 
* **tagKey vs tagId**

  * `tagId`: DB PK(Long) → 내부 식별자라 데이터 리셋/마이그레이션에 취약
  * `tagKey`: 업무키(String, unique) → 프론트 연동 안정적
  * 현재 구현은 `tagIds` 기반 저장(스웨거 기준). 추후 프론트가 `tagKey`를 보내는 방식으로 바꾸려면 요청 DTO/매핑만 바꾸면 됨.
* `type` 파라미터는 **DB의 tagType 값과 정확히 일치**해야 필터링됨 (`LIFESTYLE` 이런 식으로)

---

## 테스트 방법 (Swagger)

1. 태그 조회

   * `GET /api/tags?type=LIFESTYLE`
<img width="1293" height="1000" alt="image" src="https://github.com/user-attachments/assets/b9c8342e-be30-4cc0-ac03-e330e0cb518a" />

2. 유저 태그 저장(replace)

   * `POST /api/tags/user`
<img width="1270" height="921" alt="image" src="https://github.com/user-attachments/assets/02cb5400-25f9-4457-9c8d-20992ed4fbaa" />

3. 조합 생성

   * `POST /api/combos` (comboName 입력)
<img width="1277" height="1009" alt="image" src="https://github.com/user-attachments/assets/c96534b9-5530-4dcb-95ec-43c631511758" />

4. 온보딩 완료

   * `POST /api/onboarding/complete`
<img width="1271" height="837" alt="image" src="https://github.com/user-attachments/assets/28f9fe9b-a856-487e-bfc1-653e096e99ea" />



