### PR TITLE
[Feat] Lifestyle 태그별 대표 추천(3슬롯) + Discord 슬래시 커맨드로 관리 기능 추가

### DIFF
--- a/devicelife-api/build.gradle
+++ b/devicelife-api/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	//testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15"
+    implementation "net.dv8tion:JDA:5.0.0-beta.24"
+
 }
 
 tasks.named('test') {

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/lifestyle/DeviceAdminController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/lifestyle/DeviceAdminController.java
@@ -1,0 +1,42 @@
+package com.devicelife.devicelife_api.controller.lifestyle;
+
+import com.devicelife.devicelife_api.common.exception.CustomException;
+import com.devicelife.devicelife_api.common.exception.ErrorCode;
+import com.devicelife.devicelife_api.common.response.ApiResponse;
+import com.devicelife.devicelife_api.domain.lifestyle.request.DeviceSearchDto;
+import com.devicelife.devicelife_api.repository.lifestyle.DeviceSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/devices")
+public class DeviceAdminController {
+
+    private final DeviceSearchRepository deviceSearchRepository;
+
+    @Value("${internal.admin-token:}")
+    private String expectedToken;
+
+    @GetMapping("/search")
+    public ApiResponse<List<DeviceSearchDto>> search(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        if (expectedToken == null || expectedToken.isBlank()) {
+            throw new CustomException(ErrorCode.SERVER_5001, "internal.admin-token 설정이 비어있습니다.");
+        }
+        if (token == null || !token.equals(expectedToken)) {
+            throw new CustomException(ErrorCode.AUTH_4031, "토큰 불일치");
+        }
+
+        int safeLimit = Math.min(Math.max(limit, 1), 30);
+        List<DeviceSearchDto> result = deviceSearchRepository.searchByKeyword(keyword, safeLimit);
+
+        return ApiResponse.success("DEVICE_2001", "디바이스 검색에 성공했습니다.", result);
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/lifestyle/LifestyleFeaturedAdminController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/lifestyle/LifestyleFeaturedAdminController.java
@@ -1,0 +1,38 @@
+package com.devicelife.devicelife_api.controller.lifestyle;
+
+import com.devicelife.devicelife_api.common.exception.CustomException;
+import com.devicelife.devicelife_api.common.exception.ErrorCode;
+import com.devicelife.devicelife_api.common.response.ApiResponse;
+import com.devicelife.devicelife_api.domain.lifestyle.request.SetFeaturedRequest;
+import com.devicelife.devicelife_api.service.lifestyle.LifestyleFeaturedService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/lifestyle")
+public class LifestyleFeaturedAdminController {
+
+    private final LifestyleFeaturedService service;
+
+    @Value("${internal.admin-token:}")
+    private String expectedToken;
+
+    @PostMapping("/featured")
+    public ApiResponse<Void> setFeatured(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @Valid @RequestBody SetFeaturedRequest req
+    ) {
+        if (expectedToken == null || expectedToken.isBlank()) {
+            throw new CustomException(ErrorCode.SERVER_5001, "internal.admin-token 설정이 비어있습니다.");
+        }
+        if (token == null || !token.equals(expectedToken)) {
+            throw new CustomException(ErrorCode.AUTH_4031, "토큰 불일치");
+        }
+
+        service.setFeatured(req.getTagKey(), req.getDeviceId1(), req.getDeviceId2(), req.getDeviceId3());
+        return ApiResponse.success("LIFESTYLE_2002", "라이프스타일 대표 조합 설정에 성공했습니다.", null);
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/lifestyle/LifestyleFeaturedController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/lifestyle/LifestyleFeaturedController.java
@@ -1,0 +1,35 @@
+package com.devicelife.devicelife_api.controller.lifestyle;
+
+import com.devicelife.devicelife_api.common.response.ApiResponse;
+import com.devicelife.devicelife_api.domain.lifestyle.response.LifestyleFeaturedResponse;
+import com.devicelife.devicelife_api.service.lifestyle.LifestyleFeaturedService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Lifestyle", description = "라이프스타일 화면 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lifestyle")
+public class LifestyleFeaturedController {
+
+    private final LifestyleFeaturedService service;
+
+    @Operation(
+            summary = "라이프스타일 태그별 대표 추천 조합 조회",
+            description = "tagKey에 해당하는 대표 추천 기기 3개를 반환합니다. (이미지/이름/출시일/가격)"
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = LifestyleFeaturedResponse.class))
+    )
+    @GetMapping("/featured")
+    public ApiResponse<LifestyleFeaturedResponse> getFeatured(@RequestParam String tagKey) {
+        var result = service.getFeaturedByTagKey(tagKey);
+        return ApiResponse.success("LIFESTYLE_2001", "라이프스타일 대표 조합 조회에 성공했습니다.", result);
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/discord/DiscordBotConfig.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/discord/DiscordBotConfig.java
@@ -1,0 +1,36 @@
+package com.devicelife.devicelife_api.discord;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordBotConfig {
+
+    @Value("${discord.bot-token:}")
+    private String botToken;
+
+    private final LifestyleDiscordCommandListener listener;
+
+    private JDA jda;
+
+    @PostConstruct
+    public void start() throws Exception {
+        if (botToken == null || botToken.isBlank()) {
+            // 봇 안 쓸 거면 서버 기동은 되게 하고 싶으면 return 처리해도 됨
+            throw new IllegalStateException("discord.bot-token 비어있음 (.env에 DISCORD_BOT_TOKEN 넣어)");
+        }
+
+        this.jda = JDABuilder.createDefault(botToken)
+                .addEventListeners(listener)
+                .build();
+
+        // JDA 준비될 때까지 대충 기다림(서버 부팅 타이밍 안정화)
+        this.jda.awaitReady();
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/discord/LifestyleDiscordCommandListener.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/discord/LifestyleDiscordCommandListener.java
@@ -1,0 +1,103 @@
+package com.devicelife.devicelife_api.discord;
+
+
+import com.devicelife.devicelife_api.domain.lifestyle.request.DeviceSearchDto;
+import com.devicelife.devicelife_api.repository.lifestyle.DeviceSearchRepository;
+import com.devicelife.devicelife_api.service.lifestyle.LifestyleFeaturedService;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.session.ReadyEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class LifestyleDiscordCommandListener extends ListenerAdapter {
+
+    private final LifestyleFeaturedService lifestyleFeaturedService;
+    private final DeviceSearchRepository deviceSearchRepository;
+
+    @Value("${discord.guild-id:}")
+    private String guildId;
+
+    @Value("${discord.admin-role-name:admin}")
+    private String adminRoleName;
+
+    @Override
+    public void onReady(ReadyEvent event) {
+        if (guildId == null || guildId.isBlank()) return;
+
+        Guild guild = event.getJDA().getGuildById(guildId);
+        if (guild == null) return;
+
+        // 길드 커맨드로 등록(반영 빠름!)
+        guild.upsertCommand("device-search", "디바이스 검색")
+                .addOption(OptionType.STRING, "keyword", "검색어", true)
+                .addOption(OptionType.INTEGER, "limit", "최대 개수(1~30, 기본 10)", false)
+                .queue();
+
+        guild.upsertCommand("featured-set", "태그별 대표 기기 3개 설정")
+                .addOption(OptionType.STRING, "tag_key", "tagKey", true)
+                .addOption(OptionType.INTEGER, "d1", "deviceId1", true)
+                .addOption(OptionType.INTEGER, "d2", "deviceId2", true)
+                .addOption(OptionType.INTEGER, "d3", "deviceId3", true)
+                .queue();
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        switch (event.getName()) {
+            case "device-search" -> handleDeviceSearch(event);
+            case "featured-set" -> handleFeaturedSet(event);
+        }
+    }
+
+    private void handleDeviceSearch(SlashCommandInteractionEvent event) {
+        String keyword = event.getOption("keyword").getAsString();
+        int limit = event.getOption("limit") == null ? 10 : (int) event.getOption("limit").getAsLong();
+        int safeLimit = Math.min(Math.max(limit, 1), 30);
+
+        List<DeviceSearchDto> list = deviceSearchRepository.searchByKeyword(keyword, safeLimit);
+
+        if (list.isEmpty()) {
+            event.reply("검색 결과 없음").setEphemeral(true).queue();
+            return;
+        }
+
+        String msg = list.stream()
+                .limit(10)
+                .map(d -> String.format("- #%d %s", d.getDeviceId(), d.getModelName()))
+                .collect(Collectors.joining("\n"));
+
+        event.reply(msg).setEphemeral(true).queue();
+    }
+
+    private void handleFeaturedSet(SlashCommandInteractionEvent event) {
+        if (!isAdmin(event.getMember())) {
+            event.reply("권한 없음 (admin role 필요)").setEphemeral(true).queue();
+            return;
+        }
+
+        String tagKey = event.getOption("tag_key").getAsString();
+        long d1 = event.getOption("d1").getAsLong();
+        long d2 = event.getOption("d2").getAsLong();
+        long d3 = event.getOption("d3").getAsLong();
+
+        lifestyleFeaturedService.setFeatured(tagKey, d1, d2, d3);
+        event.reply("ok. 대표 기기 3개 바꿈").setEphemeral(true).queue();
+    }
+
+    private boolean isAdmin(Member member) {
+        if (member == null) return false;
+        if (adminRoleName == null || adminRoleName.isBlank()) return true; // 역할검증 끄고 싶으면 DISCORD_ADMIN_ROLE 비워
+        return member.getRoles().stream().anyMatch(r -> r.getName().equalsIgnoreCase(adminRoleName));
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/request/DeviceSearchDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/request/DeviceSearchDto.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class DeviceSearchDto {
     private Long deviceId;
-    private String displayName; // brand + model
+    private String modelName;
 }

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/request/DeviceSearchDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/request/DeviceSearchDto.java
@@ -1,0 +1,11 @@
+package com.devicelife.devicelife_api.domain.lifestyle.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeviceSearchDto {
+    private Long deviceId;
+    private String displayName; // brand + model
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/request/LifestyleFeaturedDeviceDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/request/LifestyleFeaturedDeviceDto.java
@@ -1,0 +1,18 @@
+package com.devicelife.devicelife_api.domain.lifestyle.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class LifestyleFeaturedDeviceDto {
+    private int slot;              // 1~3
+    private Long deviceId;
+    private String imageUrl;       // 대표 이미지(없으면 null)
+    private String displayName;    // brand + modelName
+    private LocalDate releaseDate; // 없으면 null
+    private Integer price;         // offers 최저가 -> 없으면 msrp -> 그래도 없으면 null
+    private String currency;       // 기본 "KRW"
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/request/SetFeaturedRequest.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/request/SetFeaturedRequest.java
@@ -1,0 +1,20 @@
+package com.devicelife.devicelife_api.domain.lifestyle.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class SetFeaturedRequest {
+    @NotBlank
+    private String tagKey;
+
+    @NotNull
+    private Long deviceId1;
+
+    @NotNull
+    private Long deviceId2;
+
+    @NotNull
+    private Long deviceId3;
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/response/LifestyleFeaturedResponse.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/lifestyle/response/LifestyleFeaturedResponse.java
@@ -1,0 +1,16 @@
+package com.devicelife.devicelife_api.domain.lifestyle.response;
+
+import com.devicelife.devicelife_api.domain.lifestyle.request.LifestyleFeaturedDeviceDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class LifestyleFeaturedResponse {
+    private String tagKey;
+    private String tagLabel;
+    private String tagType;
+    private List<LifestyleFeaturedDeviceDto> devices; // 0~3 (데이터 없으면 빈 배열)
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/lifestyle/DeviceSearchRepository.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/lifestyle/DeviceSearchRepository.java
@@ -1,0 +1,35 @@
+package com.devicelife.devicelife_api.repository.lifestyle;
+
+import com.devicelife.devicelife_api.domain.lifestyle.request.DeviceSearchDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class DeviceSearchRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public List<DeviceSearchDto> searchByKeyword(String keyword, int limit) {
+        String sql = """
+            SELECT d.deviceId, CONCAT(b.brandName, ' ', d.modelName) AS displayName
+            FROM devices d
+            JOIN brands b ON b.brandId = d.brandId
+            WHERE d.modelName LIKE :kw OR b.brandName LIKE :kw
+            ORDER BY d.deviceId DESC
+            LIMIT :limit
+        """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("kw", "%" + keyword + "%")
+                .addValue("limit", limit);
+
+        return jdbc.query(sql, params, (rs, n) ->
+                new DeviceSearchDto(rs.getLong("deviceId"), rs.getString("displayName"))
+        );
+    }
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/lifestyle/LifestyleFeaturedRepository.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/lifestyle/LifestyleFeaturedRepository.java
@@ -1,0 +1,136 @@
+package com.devicelife.devicelife_api.repository.lifestyle;
+
+import com.devicelife.devicelife_api.domain.lifestyle.request.LifestyleFeaturedDeviceDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class LifestyleFeaturedRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public LifestyleTagRow findTagByKey(String tagKey) {
+        String sql = """
+            SELECT tagId, tagKey, tagLabel, tagType
+            FROM tags
+            WHERE tagKey = :tagKey
+        """;
+        List<LifestyleTagRow> rows = jdbc.query(sql, new MapSqlParameterSource("tagKey", tagKey),
+                (rs, n) -> new LifestyleTagRow(
+                        rs.getLong("tagId"),
+                        rs.getString("tagKey"),
+                        rs.getString("tagLabel"),
+                        rs.getString("tagType")
+                ));
+        return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    /**
+     * 태그별 Featured Set upsert 후 featuredSetId 반환
+     */
+    public Long upsertFeaturedSet(Long tagId) {
+        String upsert = """
+            INSERT INTO lifestyleFeaturedSets (tagId, isActive)
+            VALUES (:tagId, 1)
+            ON DUPLICATE KEY UPDATE
+                isActive = 1,
+                updatedAt = CURRENT_TIMESTAMP
+        """;
+        jdbc.update(upsert, new MapSqlParameterSource("tagId", tagId));
+
+        String selectId = """
+            SELECT featuredSetId
+            FROM lifestyleFeaturedSets
+            WHERE tagId = :tagId
+        """;
+        List<Long> ids = jdbc.query(selectId, new MapSqlParameterSource("tagId", tagId),
+                (rs, n) -> rs.getLong("featuredSetId"));
+        return ids.isEmpty() ? null : ids.get(0);
+    }
+
+    public void replaceSetDevices(Long featuredSetId, List<Long> deviceIds3) {
+        String delete = "DELETE FROM lifestyleFeaturedSetDevices WHERE featuredSetId = :featuredSetId";
+        jdbc.update(delete, new MapSqlParameterSource("featuredSetId", featuredSetId));
+
+        String insert = """
+            INSERT INTO lifestyleFeaturedSetDevices (featuredSetId, slot, deviceId)
+            VALUES (:featuredSetId, :slot, :deviceId)
+        """;
+
+        MapSqlParameterSource[] batch = new MapSqlParameterSource[3];
+        for (int i = 0; i < 3; i++) {
+            batch[i] = new MapSqlParameterSource()
+                    .addValue("featuredSetId", featuredSetId)
+                    .addValue("slot", i + 1)
+                    .addValue("deviceId", deviceIds3.get(i));
+        }
+        jdbc.batchUpdate(insert, batch);
+    }
+
+    public boolean existsAllDevices(List<Long> deviceIds) {
+        String sql = """
+            SELECT COUNT(*) AS cnt
+            FROM devices
+            WHERE deviceId IN (:ids)
+        """;
+        Integer cnt = jdbc.queryForObject(sql, new MapSqlParameterSource("ids", deviceIds), Integer.class);
+        return cnt != null && cnt == deviceIds.size();
+    }
+
+    public List<LifestyleFeaturedDeviceDto> findFeaturedDevicesByTagKey(String tagKey) {
+        String sql = """
+            SELECT
+                sd.slot AS slot,
+                d.deviceId AS deviceId,
+                img.imageUrl AS imageUrl,
+                CONCAT(b.brandName, ' ', d.modelName) AS displayName,
+                d.releaseDate AS releaseDate,
+                COALESCE(MIN(o.price), d.msrp) AS price
+            FROM tags t
+            JOIN lifestyleFeaturedSets s
+              ON s.tagId = t.tagId AND s.isActive = 1
+            JOIN lifestyleFeaturedSetDevices sd
+              ON sd.featuredSetId = s.featuredSetId
+            JOIN devices d
+              ON d.deviceId = sd.deviceId
+            JOIN brands b
+              ON b.brandId = d.brandId
+            LEFT JOIN deviceOffers o
+              ON o.deviceId = d.deviceId AND o.price IS NOT NULL
+            LEFT JOIN (
+                SELECT di1.deviceId, di1.imageUrl
+                FROM deviceImages di1
+                JOIN (
+                    SELECT deviceId, MIN(sortOrder) AS minSort
+                    FROM deviceImages
+                    GROUP BY deviceId
+                ) m ON m.deviceId = di1.deviceId AND m.minSort = di1.sortOrder
+            ) img ON img.deviceId = d.deviceId
+            WHERE t.tagKey = :tagKey
+            GROUP BY sd.slot, d.deviceId, img.imageUrl, b.brandName, d.modelName, d.releaseDate, d.msrp
+            ORDER BY sd.slot ASC
+        """;
+
+        return jdbc.query(sql, new MapSqlParameterSource("tagKey", tagKey), (rs, n) -> {
+            LocalDate releaseDate = rs.getObject("releaseDate", LocalDate.class);
+            Integer price = (Integer) rs.getObject("price");
+            return new LifestyleFeaturedDeviceDto(
+                    rs.getInt("slot"),
+                    rs.getLong("deviceId"),
+                    rs.getString("imageUrl"),
+                    rs.getString("displayName"),
+                    releaseDate,
+                    price,
+                    "KRW"
+            );
+        });
+    }
+
+    public record LifestyleTagRow(Long tagId, String tagKey, String tagLabel, String tagType) {}
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/lifestyle/LifestyleFeaturedService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/lifestyle/LifestyleFeaturedService.java
@@ -1,0 +1,45 @@
+package com.devicelife.devicelife_api.service.lifestyle;
+
+import com.devicelife.devicelife_api.common.exception.CustomException;
+import com.devicelife.devicelife_api.common.exception.ErrorCode;
+import com.devicelife.devicelife_api.domain.lifestyle.response.LifestyleFeaturedResponse;
+import com.devicelife.devicelife_api.repository.lifestyle.LifestyleFeaturedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class LifestyleFeaturedService {
+
+    private final LifestyleFeaturedRepository repo;
+
+    public LifestyleFeaturedResponse getFeaturedByTagKey(String tagKey) {
+        var tag = repo.findTagByKey(tagKey);
+        if (tag == null) throw new CustomException(ErrorCode.REQ_4002, "존재하지 않는 tagKey");
+
+        var devices = repo.findFeaturedDevicesByTagKey(tagKey);
+        return new LifestyleFeaturedResponse(tag.tagKey(), tag.tagLabel(), tag.tagType(), devices);
+    }
+
+    @Transactional
+    public void setFeatured(String tagKey, Long d1, Long d2, Long d3) {
+        // 기기 중복 금지
+        Set<Long> uniq = new HashSet<>(List.of(d1, d2, d3));
+        if (uniq.size() != 3) throw new CustomException(ErrorCode.REQ_4002, "deviceId 중복");
+
+        var tag = repo.findTagByKey(tagKey);
+        if (tag == null) throw new CustomException(ErrorCode.REQ_4002, "존재하지 않는 tagKey");
+
+        List<Long> ids = List.of(d1, d2, d3);
+        if (!repo.existsAllDevices(ids)) throw new CustomException(ErrorCode.REQ_4002, "존재하지 않는 deviceId 포함");
+
+        Long featuredSetId = repo.upsertFeaturedSet(tag.tagId());
+        if (featuredSetId == null) throw new CustomException(ErrorCode.SERVER_5001, "featuredSet 생성 실패");
+
+        // slot 1~3으로 저장 (박스들의 인덱스)
+        repo.replaceSetDevices(featuredSetId, ids);
+    }
+}

--- a/devicelife-api/src/main/resources/application.yaml
+++ b/devicelife-api/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     import: optional:file:./devicelife-api/.env[.properties]
 
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=true&requireSSL=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -23,3 +23,9 @@ server:
 
 internal:
   admin-token: ${INTERNAL_ADMIN_TOKEN:}
+
+discord:
+  bot-token: ${DISCORD_BOT_TOKEN:}
+  guild-id: ${DISCORD_GUILD_ID:}
+  admin-role-name: ${DISCORD_ADMIN_ROLE:admin}
+

--- a/devicelife-api/src/main/resources/application.yaml
+++ b/devicelife-api/src/main/resources/application.yaml
@@ -20,3 +20,6 @@ spring:
 
 server:
   port: 8080
+
+internal:
+  admin-token: ${INTERNAL_ADMIN_TOKEN:}

--- a/devicelife-api/src/main/resources/db/migration/V2__lifestyle_featured.sql
+++ b/devicelife-api/src/main/resources/db/migration/V2__lifestyle_featured.sql
@@ -1,0 +1,29 @@
+-- 태그별 대표 추천 세트(=조합 1개)
+CREATE TABLE `lifestyleFeaturedSets` (
+                                         `featuredSetId` BIGINT NOT NULL AUTO_INCREMENT,
+                                         `tagId` BIGINT NOT NULL,
+                                         `isActive` TINYINT(1) NOT NULL DEFAULT 1,
+                                         `createdAt` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                         `updatedAt` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                                         PRIMARY KEY (`featuredSetId`),
+                                         UNIQUE KEY `uk_lfs_tagId` (`tagId`),
+                                         CONSTRAINT `fk_lfs_tags`
+                                             FOREIGN KEY (`tagId`) REFERENCES `tags` (`tagId`)
+                                                 ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 세트에 들어가는 3개 기기
+CREATE TABLE `lifestyleFeaturedSetDevices` (
+                                               `featuredSetId` BIGINT NOT NULL,
+                                               `slot` TINYINT NOT NULL,         -- 1~3
+                                               `deviceId` BIGINT NOT NULL,
+                                               `createdAt` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                               PRIMARY KEY (`featuredSetId`, `slot`),
+                                               UNIQUE KEY `uk_lfsd_device` (`featuredSetId`, `deviceId`),
+                                               CONSTRAINT `fk_lfsd_set`
+                                                   FOREIGN KEY (`featuredSetId`) REFERENCES `lifestyleFeaturedSets` (`featuredSetId`)
+                                                       ON DELETE CASCADE,
+                                               CONSTRAINT `fk_lfsd_device`
+                                                   FOREIGN KEY (`deviceId`) REFERENCES `devices` (`deviceId`)
+                                                       ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## 변경 요약

* 라이프스타일 태그별 “대표 추천 기기 3개(슬롯 1~3)”를 DB에 저장/조회하는 기능 추가
* Discord 봇 슬래시 커맨드로 관리자(역할 기반)만 대표 추천을 변경 가능하게 구성
* 프론트 화면 없어도 Swagger/Discord/DB로 end-to-end 테스트 가능

---

## 핵심 기능

### 1) 태그별 대표 추천 3개 세트 저장 구조

* `lifestyleFeaturedSets`: tagId 당 1개 세트(Unique)
* `lifestyleFeaturedSetDevices`: featuredSetId 당 slot 1~3에 deviceId 저장
* 슬롯 순서는 UI 박스 3개 매핑용(박스 순서 의미 강하게 두지 않아도 됨..)

### 2) 조회 API (프론트 연동 필요)

* `GET /api/lifestyle/featured?tagKey=...`

  * 특정 tagKey(Office 등) 기준으로 대표 추천 3개 기기 정보를 내려줌
  * 프론트 라이프스타일 화면에서 “태그 클릭 → 3개 박스 렌더링” 용도

### 3) 설정 API (프론트 연동 불필요 / 운영용)

* `POST /api/admin/lifestyle/featured`

  * tagKey + deviceId 3개를 받아 대표 추천 세트 갱신
  * 운영은 Discord 커맨드로만 사용할 예정이라 프론트 연동 안 함
  * 검증:

    * deviceId 중복 금지
    * tagKey 존재 확인
    * deviceId 존재 확인
    * 세트 upsert 후 slot 1~3 replace

---

## Discord 연동 (운영 플로우)

### 동작 원리

* Spring WAS 내부에서 JDA Listener가 Discord 이벤트 수신
* 앱이 켜질 때 `onReady()`에서 길드 커맨드 등록(upsert)
* 슬래시 입력 → Discord가 봇에 이벤트 전달 → Spring이 DB 조회/갱신 → ephemeral 응답(본인만 보임)

### 슬래시 커맨드

#### 1) `/device-search`

* 목적: 디바이스 id 찾기(대표 추천 변경 전에 id 확인)
* 옵션:

  * `keyword` (필수): modelName 기준 검색어
  * `limit` (선택, 기본 10): 1~30 범위로 클램프
* 출력: `#deviceId modelName` 리스트

#### 2) `/featured-set`

* 목적: 특정 tagKey에 대표 추천 3개 기기 세팅
* 옵션:

  * `tag_key` (필수): 예) Office
  * `d1, d2, d3` (필수): deviceId 3개
* 권한:

  * Discord role name `admin` 가진 멤버만 가능
  * 없으면 “권한 없음 (admin role 필요)” ephemeral

---

## 테스트 방법 (프론트 없이)

### 0) 기본 데이터 준비

* tags에 라이프스타일 tagKey 6~7개 삽입
* devices / deviceImages 등 seed 데이터 삽입
* lifestyleFeaturedSets / lifestyleFeaturedSetDevices 생성(Flyway V2) 및 초기 세팅

### 1) Discord에서 테스트

1. 서버에 봇 초대 완료
2. `admin` 역할 부여받은 계정으로:

   * `/device-search keyword: SEED`
   * 나온 deviceId 3개 골라서
   * `/featured-set tag_key: Office d1:1 d2:2 d3:3`
3. 응답 “ok. 대표 기기 3개 바꿈” 확인

### 2) Swagger로 조회 검증(프론트 API)

* `GET /api/lifestyle/featured?tagKey=Office`
* 응답의 devices 3개가 방금 세팅한 deviceId와 매칭되는지 확인

### 3) DB 직접 검증

* `lifestyleFeaturedSets`에서 Office tagId의 featuredSetId 확인
* `lifestyleFeaturedSetDevices`에서 slot 1~3의 deviceId 확인

---

## 프론트 연동 필요한 API 
@waldls 
 
* ✅ `GET /api/lifestyle/featured?tagKey=...`

  * 라이프스타일 화면 렌더링에 필요

## 프론트 연동 불필요(운영/관리용)

* ❌ `POST /api/admin/lifestyle/featured`

  * Discord 슬래시 커맨드로만 사용 예정
* ❌ `/api/admin/devices/search` (있다면)

  * 운영 편의용(디바이스 id 찾기), 프론트 화면엔 필요 없음

---

## 주의/메모

* 로컬 DB에 데이터 없으면 조회 결과 비어있는 게 정상
* `admin` role 이름은 `@admin`이 아니라 실제 role name 문자열 `admin` 기준으로 체크
* Flyway 오류(`Public Key Retrieval is not allowed`)는 JDBC 옵션/계정 auth 플러그인 문제로 별도 해결 필요(로컬 .env 및 application.yml 확인)

---

## 스크린샷/증빙(선택)

<img width="2577" height="1093" alt="image" src="https://github.com/user-attachments/assets/58400f00-b0e4-4527-8e49-8749890b8efb" />
<img width="1602" height="812" alt="image" src="https://github.com/user-attachments/assets/8f3c6003-4f8e-4ea3-9060-3dedd51b2ffc" />
<img width="1975" height="1262" alt="image" src="https://github.com/user-attachments/assets/4fbd1f52-bbe3-468c-8b12-73437ad0ac00" />

