### PR TITLE
[Feat] 기존 userId 받던 방식 JWT 토큰 추출 방식으로 수정

### DIFF
--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/security/CustomUserDetails.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/security/CustomUserDetails.java
@@ -28,4 +28,6 @@ public class CustomUserDetails implements UserDetails {
     public String getUsername() {
         return user.getEmail();
     }
+
+    public Long getId() {return user.getUserId();}
 }

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/combo/ComboController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/combo/ComboController.java
@@ -2,6 +2,7 @@ package com.devicelife.devicelife_api.controller.combo;
 
 import com.devicelife.devicelife_api.common.response.ApiResponse;
 import com.devicelife.devicelife_api.common.response.SuccessCode;
+import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.combo.dto.request.ComboCreateRequestDto;
 import com.devicelife.devicelife_api.domain.combo.dto.request.ComboDeviceAddRequestDto;
 import com.devicelife.devicelife_api.domain.combo.dto.request.ComboPermanentDeleteRequestDto;
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -43,10 +45,6 @@ public class ComboController {
             summary = "조합 생성",
             description = """
             comboName을 받아 combos 테이블에 조합을 생성한다.
-
-            [JWT 전환 예정]
-            - 현재: userId를 요청 바디로 받음
-            - 추후: JWT 인증 도입 시 userId는 토큰에서 추출하도록 변경
             """
     )
     @ApiResponses({
@@ -66,13 +64,13 @@ public class ComboController {
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
                     description = """
-                    - userId: 임시(인증 도입 후 토큰에서 추출하도록 변경)
                     - comboName: 최대 80자(Combo 엔티티 제약)
                     """,
                     content = @Content(schema = @Schema(implementation = ComboCreateRequestDto.class))
             )
-            @Valid @RequestBody ComboCreateRequestDto request) {
-        ComboCreateResponseDto result = comboService.createCombo(request);
+            @Valid @RequestBody ComboCreateRequestDto request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        ComboCreateResponseDto result = comboService.createCombo(request,customUserDetails);
         return ResponseEntity.ok(
                 ApiResponse.success(
                         SuccessCode.COMBO_CREATE_SUCCESS.getCode(),
@@ -119,10 +117,6 @@ public class ComboController {
             description = """
             특정 사용자의 활성 조합 목록을 조회한다. (삭제되지 않은 조합만)
             즐겨찾기가 있으면 상단에 표시된다.
-            
-            [JWT 전환 예정]
-            - 현재: userId를 쿼리 파라미터로 받음
-            - 추후: JWT 인증 도입 시 userId는 토큰에서 추출하도록 변경
             """
     )
     @ApiResponses({
@@ -139,8 +133,8 @@ public class ComboController {
     })
     @GetMapping
     public ResponseEntity<ApiResponse<List<ComboListResponseDto>>> getComboList(
-            @RequestParam Long userId) {
-        List<ComboListResponseDto> result = comboService.getComboList(userId);
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        List<ComboListResponseDto> result = comboService.getComboList(customUserDetails);
         return ResponseEntity.ok(
                 ApiResponse.success(
                         SuccessCode.COMBO_LIST_SUCCESS.getCode(),
@@ -338,10 +332,6 @@ public class ComboController {
             description = """
             사용자의 휴지통에 있는 조합 목록을 조회한다.
             각 조합의 영구 삭제까지 남은 일수를 함께 반환한다.
-            
-            [JWT 전환 예정]
-            - 현재: userId를 쿼리 파라미터로 받음
-            - 추후: JWT 인증 도입 시 userId는 토큰에서 추출하도록 변경
             """
     )
     @ApiResponses({
@@ -358,8 +348,8 @@ public class ComboController {
     })
     @GetMapping("/trash")
     public ResponseEntity<ApiResponse<List<ComboTrashResponseDto>>> getTrashList(
-            @RequestParam Long userId) {
-        List<ComboTrashResponseDto> result = comboService.getTrashList(userId);
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        List<ComboTrashResponseDto> result = comboService.getTrashList(customUserDetails);
         return ResponseEntity.ok(
                 ApiResponse.success(
                         SuccessCode.COMBO_TRASH_LIST_SUCCESS.getCode(),

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/onboarding/OnboardingController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/onboarding/OnboardingController.java
@@ -2,6 +2,7 @@ package com.devicelife.devicelife_api.controller.onboarding;
 
 import com.devicelife.devicelife_api.common.response.ApiResponse;
 import com.devicelife.devicelife_api.common.response.SuccessCode;
+import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.onboarding.dto.request.OnboardingCompleteRequestDto;
 import com.devicelife.devicelife_api.service.onboarding.OnboardingService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,10 +36,6 @@ public class OnboardingController {
             summary = "온보딩 완료 처리",
             description = """
             users.onboardingCompleted를 true로 설정한다.
-
-            [JWT 전환 예정]
-            - 현재: userId를 요청 바디로 받음
-            - 추후: JWT 인증 도입 시 userId는 토큰에서 추출하도록 변경
             """
     )
     @ApiResponses({
@@ -54,13 +52,13 @@ public class OnboardingController {
     })
     @PostMapping("/complete")
     public ResponseEntity<ApiResponse<Void>> complete(
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    required = true,
-                    description = "userId는 임시(인증 도입 후 토큰에서 추출하도록 변경).",
-                    content = @Content(schema = @Schema(implementation = OnboardingCompleteRequestDto.class))
-            )
-            @Valid @RequestBody OnboardingCompleteRequestDto request) {
-        onboardingService.complete(request);
+            //@io.swagger.v3.oas.annotations.parameters.RequestBody(
+            //        required = true,
+            //        description = "userId는 임시(인증 도입 후 토큰에서 추출하도록 변경).",
+            //        content = @Content(schema = @Schema(implementation = OnboardingCompleteRequestDto.class))
+            //)
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        onboardingService.complete(customUserDetails);
         return ResponseEntity.ok(
                 ApiResponse.success(
                         SuccessCode.ONBOARDING_COMPLETE_SUCCESS.getCode(),

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/tag/TagController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/tag/TagController.java
@@ -2,6 +2,7 @@ package com.devicelife.devicelife_api.controller.tag;
 
 import com.devicelife.devicelife_api.common.response.ApiResponse;
 import com.devicelife.devicelife_api.common.response.SuccessCode;
+import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.device.dto.request.UserTagRequestDto;
 import com.devicelife.devicelife_api.domain.device.dto.response.TagResponseDto;
 import com.devicelife.devicelife_api.service.tag.TagService;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -83,10 +85,6 @@ public class TagController {
             [왜 replace?]
             - 온보딩/선택 UI에서 유저가 선택을 바꾸는 게 자연스러움.
               add-only(추가만)로 저장하면 사용자가 '해제'한 태그가 DB에 남아 데이터가 망가짐.
-
-            [JWT 전환 예정]
-            - 현재는 userId를 바디로 받음(임시).
-            - JWT 적용 후에는 userId를 토큰에서 추출하도록 바꿀 것.
             """
     )
     @ApiResponses({
@@ -102,8 +100,10 @@ public class TagController {
             )
     })
     @PostMapping("/user")
-    public ResponseEntity<ApiResponse<Void>> saveUserTags(@Valid @RequestBody UserTagRequestDto request) {
-        tagService.saveUserTags(request);
+    public ResponseEntity<ApiResponse<Void>> saveUserTags(
+            @Valid @RequestBody UserTagRequestDto request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        tagService.saveUserTags(request,customUserDetails);
         return ResponseEntity.ok(
                 ApiResponse.success(
                         SuccessCode.TAG_SAVE_SUCCESS.getCode(),

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/combo/dto/request/ComboCreateRequestDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/combo/dto/request/ComboCreateRequestDto.java
@@ -8,8 +8,9 @@ import lombok.Getter;
 @Getter
 public class ComboCreateRequestDto {
 
-    @NotNull
-    private Long userId;
+    //JWT 도입 완료하여 주석처리
+    //@NotNull
+    //private Long userId;
 
     @NotBlank
     @Size(max = 80)

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/device/dto/request/UserTagRequestDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/device/dto/request/UserTagRequestDto.java
@@ -9,8 +9,9 @@ import java.util.List;
 @Getter
 public class UserTagRequestDto {
 
-    @NotNull
-    private Long userId;
+    //JWT 토큰 도입 완료하여 주석처리
+    //@NotNull
+    //private Long userId;
 
     @NotEmpty
     private List<Long> tagIds;

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/combo/ComboService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/combo/ComboService.java
@@ -2,6 +2,7 @@ package com.devicelife.devicelife_api.service.combo;
 
 import com.devicelife.devicelife_api.common.exception.CustomException;
 import com.devicelife.devicelife_api.common.exception.ErrorCode;
+import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.combo.Combo;
 import com.devicelife.devicelife_api.domain.combo.ComboDevice;
 import com.devicelife.devicelife_api.domain.combo.ComboDeviceId;
@@ -35,8 +36,8 @@ public class ComboService {
      * 조합 생성
      */
     @Transactional
-    public ComboCreateResponseDto createCombo(ComboCreateRequestDto request) {
-        Long userId = request.getUserId();
+    public ComboCreateResponseDto createCombo(ComboCreateRequestDto request, CustomUserDetails cud) {
+        Long userId = cud.getId();
 
         User user = em.find(User.class, userId);
         if (user == null) {
@@ -95,7 +96,10 @@ public class ComboService {
      * 조합 목록 조회 (활성 조합만)
      */
     @Transactional(readOnly = true)
-    public List<ComboListResponseDto> getComboList(Long userId) {
+    public List<ComboListResponseDto> getComboList(CustomUserDetails cud) {
+
+        Long userId = cud.getId();
+
         User user = em.find(User.class, userId);
         if (user == null) {
             throw new CustomException(ErrorCode.USER_4041);
@@ -215,7 +219,10 @@ public class ComboService {
      * 휴지통 목록 조회
      */
     @Transactional(readOnly = true)
-    public List<ComboTrashResponseDto> getTrashList(Long userId) {
+    public List<ComboTrashResponseDto> getTrashList(CustomUserDetails cud) {
+
+        Long userId = cud.getId();
+
         User user = em.find(User.class, userId);
         if (user == null) {
             throw new CustomException(ErrorCode.USER_4041);

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/onboarding/OnboardingService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/onboarding/OnboardingService.java
@@ -1,5 +1,6 @@
 package com.devicelife.devicelife_api.service.onboarding;
 
+import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.onboarding.dto.request.OnboardingCompleteRequestDto;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
@@ -14,8 +15,8 @@ public class OnboardingService {
     private final EntityManager em;
 
     @Transactional
-    public void complete(OnboardingCompleteRequestDto request) {
-        Long userId = request.getUserId();
+    public void complete(CustomUserDetails cud) {
+        Long userId = cud.getId();
 
         int updated = em.createQuery(
                         "update User u set u.onboardingCompleted = true where u.userId = :userId"

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/tag/TagService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/tag/TagService.java
@@ -1,5 +1,6 @@
 package com.devicelife.devicelife_api.service.tag;
 
+import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.device.Tag;
 import com.devicelife.devicelife_api.domain.device.dto.request.UserTagRequestDto;
 import com.devicelife.devicelife_api.domain.device.dto.response.TagResponseDto;
@@ -43,8 +44,8 @@ public class TagService {
     }
 
     @Transactional
-    public void saveUserTags(UserTagRequestDto request) {
-        Long userId = request.getUserId();
+    public void saveUserTags(UserTagRequestDto request, CustomUserDetails cud) {
+        Long userId = cud.getId();
 
         User user = em.find(User.class, userId);
         if (user == null) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
로그인 구현 완료 전
request로 userId 받던 API들을 JWT 토큰에서 유저정보 추출하는 방식으로 수정

-수정한 API 목록
POST api/tags/user
GET api/combos
POST api/combos
GET api/combos/trash
POST api/onboarding/complete

### 스크린샷 (선택)
<img width="1456" height="1026" alt="스크린샷 2026-01-13 오전 1 34 35" src="https://github.com/user-attachments/assets/eacddd2e-3509-4854-af28-cfd5fe68c7fa" />
<img width="1474" height="874" alt="스크린샷 2026-01-13 오전 1 48 09" src="https://github.com/user-attachments/assets/56ab7cb1-070a-4c29-acab-526378a32740" />
<img width="1508" height="1188" alt="스크린샷 2026-01-13 오전 1 50 28" src="https://github.com/user-attachments/assets/2878ac9d-91c7-4231-882b-a8b71a7574bc" />
<img width="1486" height="1128" alt="스크린샷 2026-01-13 오전 1 53 20" src="https://github.com/user-attachments/assets/30196d20-b38d-4f55-a6e7-337489b77473" />
<img width="1458" height="1282" alt="스크린샷 2026-01-13 오전 1 54 38" src="https://github.com/user-attachments/assets/c4ffa212-7692-4a7f-a2b1-1478881e8c69" />


## 💬리뷰 요구사항(선택)
DB에 변경사항 반영여부랑 userId 주입여부 모두 확인해보긴했지만,
제가 개발한 API가 아닌지라 더미데이터가 넉넉하진 않아서
그냥 확인차 해당 API 개발하신 은서씨 태훈씨 리뷰어로 태그 달아놨습니다.