### PR TITLE
[Docs] 권한 경로 지정, 스웨거 문서 수정

### DIFF
--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/config/SecurityConfig.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/config/SecurityConfig.java
@@ -44,10 +44,31 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/v3/api-docs/**"
                         ).permitAll()
-                        //.requestMatchers("/api/auth/").hasRole("USER")
-                        .requestMatchers("/api/**").permitAll()
+                        .requestMatchers(
+                                "/api/combos/**",
+                                "/api/tags/**",
+                                "/api/auth/refresh",
+                                "/api/tags/logout",
+                                "api/onboarding/**",
+                                "api/mypage/**"
+                                ).authenticated()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, e) -> {
+                            res.setStatus(401);
+                            res.setContentType("application/json;charset=UTF-8");
+                            res.getWriter().write("""
+                {"isSuccess":false,"code":"AUTH_401","message":"인증이 필요합니다.","result":null,"error":null}
+              """);
+                        })
+                        .accessDeniedHandler((req, res, e) -> {
+                            res.setStatus(403);
+                            res.setContentType("application/json;charset=UTF-8");
+                            res.getWriter().write("""
+                {"isSuccess":false,"code":"AUTH_403","message":"권한이 없습니다.","result":null,"error":null}
+              """);
+                        }))
 
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/config/SwaggerConfig.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/config/SwaggerConfig.java
@@ -33,7 +33,7 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(info)
                 .addServersItem(new Server().url("/"))
-                .addSecurityItem(securityRequirement)
+                //.addSecurityItem(securityRequirement)
                 .components(components);
     }
 }

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/auth/AuthController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/auth/AuthController.java
@@ -4,6 +4,10 @@ import com.devicelife.devicelife_api.common.response.ApiResponse;
 import com.devicelife.devicelife_api.domain.user.dto.AuthDto;
 import com.devicelife.devicelife_api.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +30,18 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 ",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4001",
+                    description = "이미 중복되는 email (중복금지)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
     @PostMapping("/join")
     @Operation(summary = "회원가입 API", description = "아이디(이메일), 비밀번호, 닉네임, 전화번호 입력")
     public ApiResponse<AuthDto.joinResDto> join(@RequestBody @Valid AuthDto.joinReqDto dto) {
@@ -35,6 +51,23 @@ public class AuthController {
                 authService.join(dto));
     }
 
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 ",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4041",
+                    description = "해당 email을 사용하는 사용자가 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4006",
+                    description = "비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
     @PostMapping("/login")
     @Operation(summary = "로그인 API", description = "아이디(이메일), 비밀번호 입력")
     public ApiResponse<AuthDto.loginResDto> login(@RequestBody @Valid AuthDto.loginReqDto dto) {
@@ -45,6 +78,24 @@ public class AuthController {
         );
     }
 
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 ",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4012",
+                    description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4013",
+                    description = "이미 로그아웃 처리된 토큰이거나 존재하지 않는 토큰",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    @SecurityRequirement(name = "JWT TOKEN")
     @PostMapping("/refresh")
     @Operation(summary = "accessToken 재발급 API", description = "리프레시 토큰을 통해 엑세스 토큰 재발급")
     public ApiResponse<AuthDto.refreshResDto> refresh(@RequestHeader("refreshToken") String refreshToken) {
@@ -54,6 +105,14 @@ public class AuthController {
                 authService.refresh(refreshToken));
     }
 
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 ",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    @SecurityRequirement(name = "JWT TOKEN")
     @PostMapping("/logout")
     @Operation(summary = "로그아웃 API", description = "로그아웃 API 호출 시 DB 내 리프레시 토큰 정보 삭제")
     public ApiResponse<Void> logout(@RequestHeader("refreshToken") String refreshToken) {

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/combo/ComboController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/combo/ComboController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ import java.util.List;
 )
 @RestController
 @RequiredArgsConstructor
+@SecurityRequirement(name = "JWT TOKEN")
 @RequestMapping("/api/combos")
 public class ComboController {
 
@@ -352,6 +354,7 @@ public class ComboController {
                     content = @Content(schema = @Schema(implementation = ApiResponse.class))
             )
     })
+    @SecurityRequirement(name = "JWT TOKEN")
     @DeleteMapping("/{comboId}/devices/{deviceId}")
     public ResponseEntity<ApiResponse<ComboDetailResponseDto>> removeDeviceFromCombo(
             @PathVariable Long comboId,

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/mypageprofile/MyPageProfileController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/mypageprofile/MyPageProfileController.java
@@ -5,6 +5,10 @@ import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.user.dto.MyPageProfileDto;
 import com.devicelife.devicelife_api.service.mypageprofile.MypageProfileService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +30,7 @@ import static com.devicelife.devicelife_api.common.response.SuccessCode.USER_200
 
 @RestController
 @RequiredArgsConstructor
+@SecurityRequirement(name = "JWT TOKEN")
 @RequestMapping("/api/mypage")
 public class MyPageProfileController {
 
@@ -41,6 +46,38 @@ public class MyPageProfileController {
                 mypageProfileService.myProfileInfo(customUserDetails));
     }
 
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 ",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4041",
+                    description = "해당 email을 사용하는 사용자가 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4004",
+                    description = "닉네임 미입력",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4002",
+                    description = "이메일 미입력",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4003",
+                    description = "소셜 유저의 경우 email 수정 불가",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4009",
+                    description = "이미 사용중인 email",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
     @PatchMapping("/user-profile")
     @Operation(summary = "프로필 수정 API", description = """
             - 닉네임, 이메일, 라이프스타일 태그 수정
@@ -59,6 +96,33 @@ public class MyPageProfileController {
                 mypageProfileService.modifyMyProfileInfo(dto,customUserDetails));
     }
 
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 ",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4005",
+                    description = "소셜 로그인으로 신규 가입한 유저는 비밀번호 존재 X",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4006",
+                    description = "기존 비밀번호 일치 X",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4007",
+                    description = "새 비밀번호와 새 비밀번호 확인 미일치",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "USER_4008",
+                    description = "새 비밀번호는 기존 비밀번호와 다르게 설정해야함",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
     @PutMapping("/user-profile/password")
     @Operation(summary = "비밀번호 수정 API", description = """
             기존 비밀번호, 새 비밀번호, 새 비밀번호 확인

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/onboarding/OnboardingController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/onboarding/OnboardingController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 )
 @RestController
 @RequiredArgsConstructor
+@SecurityRequirement(name = "JWT TOKEN")
 @RequestMapping("/api/onboarding")
 public class OnboardingController {
 

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/tag/TagController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/tag/TagController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/tags")
+@SecurityRequirement(name = "JWT TOKEN")
 @RequiredArgsConstructor
 public class TagController {
 

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/auth/AuthService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/auth/AuthService.java
@@ -57,7 +57,7 @@ public class AuthService {
                 .orElseThrow(() -> new CustomException(USER_4041));
 
         if (!passwordEncoder.matches(req.getPassword(), user.getPasswordHash())){
-            throw new CustomException(USER_4001);
+            throw new CustomException(USER_4006);
         }
 
         CustomUserDetails userDetails = new CustomUserDetails(user);

--- a/devicelife-api/src/main/resources/application.yaml
+++ b/devicelife-api/src/main/resources/application.yaml
@@ -40,7 +40,7 @@ jwt:
   token:
     secretKey: ${JWT_SECRET_KEY}
     expiration:
-      access: 14400000 # 4시간
+      access: 86400000 # 14400000 # PM님의 요청으로 데모데이 전까지만 토큰 기한 24시간으로 설정 (기존 4시간)
       refresh: 1209600000 # 14일
 
 server:


### PR DESCRIPTION
## 📝작업 내용

1. 비회원 허용 API랑 회원전용 API 구분 표시 (오른쪽에 자물쇠 표시 )
(약관,문의,공지사항,FAQ는 하드코딩으로 전환되었다고 전달받아서 안건드렸습니다.)
2. 비회원이 회원전용 API로 접근할 경우 401 에러 발생으로 수정 (기존은 500이었음)
3. 스웨거 문서 에러케이스 추가
4. PM님의 요청으로 데모데이 전까지만 토큰 기한 24시간으로 설정

### 스크린샷
<img width="2930" height="698" alt="스크린샷 2026-01-21 오후 7 21 18" src="https://github.com/user-attachments/assets/56604b13-080e-42e2-843b-aa6f43c32d67" />
<img width="1112" height="1032" alt="스크린샷 2026-01-21 오후 8 34 39" src="https://github.com/user-attachments/assets/3f882931-cb6c-4be4-b7bf-80577c1e24ca" />
<img width="718" height="766" alt="스크린샷 2026-01-21 오후 8 45 35" src="https://github.com/user-attachments/assets/aa4ea3d0-2e4e-417e-9983-a8a4b601a61b" />

