### PR TITLE
[Fix] 워커가 라이프 스타일 태그도 받아올수 있도록 수정

### DIFF
--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/security/JwtAuthFilter.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/security/JwtAuthFilter.java
@@ -34,10 +34,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
 
-        if (request.getRequestURI().startsWith("/internal/")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+        //if (request.getRequestURI().startsWith("/internal/")) {
+        //    filterChain.doFilter(request, response);
+        //    return;
+        //}
 
         String authHeader = request.getHeader("Authorization");
 

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/evaluation/EvaluationController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/evaluation/EvaluationController.java
@@ -1,6 +1,7 @@
 package com.devicelife.devicelife_api.controller.evaluation;
 
 import com.devicelife.devicelife_api.common.response.ApiResponse;
+import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.evaluation.dto.EvaluationDto;
 import com.devicelife.devicelife_api.domain.evaluation.dto.EvaluationPayloadResDto;
 import com.devicelife.devicelife_api.service.evaluation.EvaluationService;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import static com.devicelife.devicelife_api.common.response.SuccessCode.COMBO_LIST_SUCCESS;
@@ -26,6 +28,7 @@ import static com.devicelife.devicelife_api.common.response.SuccessCode.COMMON_2
 )
 @RestController
 @RequiredArgsConstructor
+@SecurityRequirement(name = "JWT TOKEN")
 @RequestMapping("/internal/evaluations")
 public class EvaluationController {
 
@@ -52,12 +55,14 @@ public class EvaluationController {
             )
     })
     @GetMapping("/{combinationId}/payload")
-    public ApiResponse<EvaluationPayloadResDto> getData(@PathVariable Long combinationId) {
+    public ApiResponse<EvaluationPayloadResDto> getData(
+            @PathVariable Long combinationId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         return ApiResponse.success(
                 COMBO_LIST_SUCCESS.getCode(),
                 COMBO_LIST_SUCCESS.getMessage(),
-                evaluationService.getDevicesData(combinationId));
+                evaluationService.getDevicesData(combinationId, customUserDetails));
     }
 
     @Operation(

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/evaluation/dto/EvaluationPayloadResDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/evaluation/dto/EvaluationPayloadResDto.java
@@ -19,6 +19,7 @@ public class EvaluationPayloadResDto {
     private Long evaluationVersion;
     private String jobId;
     private List<DeviceDto> devices;
+    private List<String> lifestyles;
 
     /* =========================
      * Device wrapper

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/evaluation/EvaluationService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/evaluation/EvaluationService.java
@@ -1,15 +1,18 @@
 package com.devicelife.devicelife_api.service.evaluation;
 
 import com.devicelife.devicelife_api.common.exception.CustomException;
+import com.devicelife.devicelife_api.common.security.CustomUserDetails;
 import com.devicelife.devicelife_api.domain.combo.Combo;
 import com.devicelife.devicelife_api.domain.combo.ComboDevice;
 import com.devicelife.devicelife_api.domain.device.*;
 import com.devicelife.devicelife_api.domain.evaluation.Evaluation;
 import com.devicelife.devicelife_api.domain.evaluation.dto.EvaluationDto;
 import com.devicelife.devicelife_api.domain.evaluation.dto.EvaluationPayloadResDto;
+import com.devicelife.devicelife_api.domain.user.User;
 import com.devicelife.devicelife_api.repository.device.*;
 import com.devicelife.devicelife_api.repository.evaluation.EvaluationRepository;
 import com.devicelife.devicelife_api.repository.combo.ComboRepository;
+import com.devicelife.devicelife_api.repository.tag.UserTagRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +30,7 @@ public class EvaluationService {
     private final EntityManager em;
     private final ComboRepository comboRepository;
     private final EvaluationRepository evaluationRepository;
+    private final UserTagRepository userTagRepository;
 
     private final SmartphoneRepository smartphoneRepository;
     private final LaptopRepository laptopRepository;
@@ -37,7 +41,10 @@ public class EvaluationService {
     private final SmartwatchRepository smartwatchRepository;
     private final AudioRepository audioRepository;
 
-    public EvaluationPayloadResDto getDevicesData (Long comboId) {
+    public EvaluationPayloadResDto getDevicesData (Long comboId, CustomUserDetails cud) {
+
+        User user = cud.getUser();
+        List<String> lifestyle = userTagRepository.findTagLabelsByUserIdOrderByTagLableAsc(user.getUserId());
 
         Combo combo = comboRepository.findByComboId(comboId)
                 .orElseThrow(() -> new CustomException(COMBO_4041));
@@ -51,7 +58,8 @@ public class EvaluationService {
                 combo.getComboId(),
                 combo.getEvaluationVersion(),
                 null,                      // jobId (없으면 null)
-                devices
+                devices,
+                lifestyle
         );
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
라이프 스타일 작업을 위해서 워커가 유저 태그도 받아올수 있도록 수정했습니다.

은서씨가 하나 참고하셔야할 점이 있는데
저번에 IP 권한 인증 이슈로 해매고 있을때
JWTAuthFilter에 추가했던 코드땜에
"/internal/**" API를 실행할때 인증을 건너뛰게 되어서
유저정보를 받아올수가 없더라고요

그래서 일단 그 부분은 주석처리했는데
추후 permitAll 없애고 다시 IP 권한 세팅할때
인증을 아예 건너뛰게 되면 문제가 생길것으로 예상되어서 
미리 참고하시면 좋을거같아여

DTO가 바뀌었으므로 워커쪽 코드도 수정해야할것같은데 일단은 졸려서 잤다가 일어나서 진행하겠습니다~


### 스크린샷 (선택)
<img width="2846" height="1446" alt="스크린샷 2026-01-28 오전 5 15 32" src="https://github.com/user-attachments/assets/59f9c3f8-3675-4f9e-bde0-8f789529d216" />


## 💬리뷰 요구사항(선택)
