### PR TITLE
[Feat] combo score get api 구현

### DIFF
--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/exception/ErrorCode.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/exception/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
     COMBO_4004("COMBO_4004", 400, "조합에 해당 기기가 없습니다."),
     COMBO_4005("COMBO_4005", 400, "이미 동일한 이름의 조합이 존재합니다."),
 
+    // Evaluation 관련 오류 (EVAL_XXXX)
+    EVAL_4041("EVAL_4041", 404, "평가 데이터를 찾을 수 없습니다."),
+
     // Tag 관련 오류 (TAG_XXXX)
     TAG_4001("TAG_4001",400,"존재하지 않는 태그가 포함되어있습니다."),
 

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/combo/ComboController.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/controller/combo/ComboController.java
@@ -497,4 +497,42 @@ public class ComboController {
                 )
         );
     }
+
+    // ========== 평가 점수 조회 (Polling 용) ==========
+
+    @Operation(
+            summary = "조합 평가 점수 조회",
+            description = """
+            특정 조합의 최신 평가 점수를 조회한다.
+            워커가 계산을 마친 후 DB에 저장된 값을 가져온다.
+            프론트엔드에서는 1초 간격으로 폴링(Polling)하여 결과를 확인해야 한다.
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "평가 데이터가 없음 (아직 계산 중이거나 조합이 없음)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    @GetMapping("/{comboId}/evaluation")
+    public ResponseEntity<ApiResponse<ComboEvaluationResponseDto>> getComboEvaluation(
+            @PathVariable Long comboId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        ComboEvaluationResponseDto result = comboService.getComboEvaluation(comboId, customUserDetails);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        SuccessCode.COMBO_GET_SUCCESS.getCode(),
+                        "평가 점수 조회 성공",
+                        result
+                )
+        );
+    }
 }

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/combo/dto/response/ComboEvaluationResponseDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/combo/dto/response/ComboEvaluationResponseDto.java
@@ -1,0 +1,22 @@
+package com.devicelife.devicelife_api.domain.combo.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ComboEvaluationResponseDto {
+    private Long comboId;
+    private int totalScore;
+    private String grade;       // HIGH, MID, LOW
+    private int connectivity;   // scoreA (연동성)
+    private int convenience;    // scoreB (편의성/품질)
+    private int lifestyle;      // scoreC (라이프스타일)
+    private LocalDateTime evaluatedAt;
+}

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/evaluation/EvaluationRepository.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/repository/evaluation/EvaluationRepository.java
@@ -17,4 +17,7 @@ public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
     @Query("delete from Evaluation e where e.comboId = :comboId")
     int deleteAllByComboId(@Param("comboId") Long comboId);
 
+    // 콤보 ID로 최신 평가 내역 조회
+    Optional<Evaluation> findByComboId(Long comboId);
+
 }

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/combo/ComboService.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/service/combo/ComboService.java
@@ -12,9 +12,11 @@ import com.devicelife.devicelife_api.domain.combo.dto.request.ComboDeviceAddRequ
 import com.devicelife.devicelife_api.domain.combo.dto.request.ComboUpdateRequestDto;
 import com.devicelife.devicelife_api.domain.combo.dto.response.*;
 import com.devicelife.devicelife_api.domain.device.Device;
+import com.devicelife.devicelife_api.domain.evaluation.Evaluation;
 import com.devicelife.devicelife_api.domain.user.User;
 import com.devicelife.devicelife_api.repository.combo.ComboDeviceRepository;
 import com.devicelife.devicelife_api.repository.combo.ComboRepository;
+import com.devicelife.devicelife_api.repository.evaluation.EvaluationRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,7 @@ public class ComboService {
 
     private final ComboRepository comboRepository;
     private final ComboDeviceRepository comboDeviceRepository;
+    private final EvaluationRepository evaluationRepository;
     private final EntityManager em;
     private final CurrencyConverter currencyConverter;
 
@@ -382,4 +385,47 @@ public class ComboService {
         LocalDateTime permanentDeleteDate = deletedAt.plusDays(30);
         return ChronoUnit.DAYS.between(LocalDateTime.now(), permanentDeleteDate);
     }
+
+    /**
+     * [신규] 조합 평가 점수 조회 (Polling용)
+     */
+    @Transactional(readOnly = true)
+    public ComboEvaluationResponseDto getComboEvaluation(Long comboId, CustomUserDetails cud) {
+        // 1. 조합 존재 확인
+        Combo combo = comboRepository.findById(comboId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMBO_4041));
+
+        // 2. 권한 검사
+        validateComboOwnership(combo, cud.getId());
+
+        // 3. 평가 데이터 조회
+        // 데이터가 없으면 예외 발생 -> 프론트엔드가 "계산 중" 상태 유지
+        Evaluation evaluation = evaluationRepository.findByComboId(comboId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EVAL_4041));
+
+        // 4. DTO 변환
+        int totalScoreInt = evaluation.getTotalScore().intValue();
+
+        return ComboEvaluationResponseDto.builder()
+                .comboId(evaluation.getComboId())
+                .totalScore(totalScoreInt)
+                .grade(getGrade(totalScoreInt)) // [수정] 보내주신 5단계 로직 적용
+                .connectivity(evaluation.getScoreA() != null ? evaluation.getScoreA().intValue() : 0) // 연동성
+                .convenience(evaluation.getScoreB() != null ? evaluation.getScoreB().intValue() : 0)  // 편의성
+                .lifestyle(evaluation.getScoreC() != null ? evaluation.getScoreC().intValue() : 0)    // 라이프스타일
+                .evaluatedAt(evaluation.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * [신규] 점수 등급 계산 (5단계)
+     */
+    private String getGrade(int score) {
+        if (score >= 90) return "최상";
+        if (score >= 80) return "상";
+        if (score >= 60) return "중";
+        if (score >= 40) return "하";
+        return "최하";
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #67 

## 📝작업 내용
현재 우리 서비스의 점수 계산 로직은 비동기(Asynchronous)로 처리됩니다.

사용자가 기기를 추가/삭제하면 백엔드 서버는 즉시 점수를 주지 않고, "계산 요청"만 큐(SQS)에 넣고 응답합니다. 실제 계산은 별도의 **Worker**가 수행하므로, DB에 점수가 반영되기까지 **약 0.5초 ~ 2초의 지연 시간**이 발생합니다.

따라서 프론트엔드는 **폴링(Polling)** 방식을 통해 점수 계산이 완료되었는지 확인해야 합니다.

### API 명세 (API Specification)

### **점수 조회 API**

- **Method:** `GET`
- **URL:** `/api/combos/{comboId}/evaluation`
- **Header:** `Authorization: Bearer {Token}`

### **응답 (Response)**

**Case 1: 계산 완료 (성공)**

- **Status:** `200 OK`
- **Body:**

```jsx
{
  "isSuccess": true,
  "code": "200",
  "message": "평가 점수 조회 성공",
  "result": {
    "comboId": 47,
    "totalScore": 86,
    "grade": "상",            // 등급: 최상, 상, 중, 하, 최하
    "connectivity": 86,       // 연동성 (scoreA)
    "convenience": 69,        // 편의성 (scoreB)
    "lifestyle": 65,          // 라이프스타일 (scoreC)
    "evaluatedAt": "2026-02-02T16:00:24"
  }
}
```

**Case 2: 계산 중 (아직 데이터 없음)**

- **Status:** `404 Not Found`
- **Body:**

```jsx
{
  "isSuccess": false,
  "code": "EVAL_4041",
  "message": "평가 데이터를 찾을 수 없습니다."
}
```

> 주의: 이 404 에러는 "실패"가 아니라 "대기(Pending)" 신호로 해석해야 합니다!
>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
