### PR TITLE
[Fix] 리프레시 토큰 전달 방식 수정 (쿠키)

### DIFF
--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/config/SecurityConfig.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/common/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin((auth) -> auth.disable())
                 .httpBasic((auth) -> auth.disable())
                 .addFilterBefore(internalTokenAuthFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/user/dto/AuthDto.java
+++ b/devicelife-api/src/main/java/com/devicelife/devicelife_api/domain/user/dto/AuthDto.java
@@ -78,6 +78,7 @@ public class AuthDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Setter
     public static class loginResDto {
         Long userId;
         String accessToken;


### PR DESCRIPTION
## 📝작업 내용
1. /api/auth/login (일반 로그인)
응답 body에서 refreshToken null값으로 픽스 (쿠키로만 전송)
Set-Cookie 헤더로 refreshToken 전송 (httpOnly, Secure, SameSite 설정)

2. /api/auth/refresh (토큰 갱신)
요청 헤더의 refreshToken 제거후 쿠키에서 읽도록 수정

3. /api/auth/logout (로그아웃)
요청 헤더의 refreshToken 제거후 쿠키에서 읽도록 수정
Set-Cookie 헤더로 refreshToken 쿠키 삭제 (Max-Age=0 또는 Expires 설정)

4. Google OAuth 콜백처리는 콜백페이지 만드시면 다시 작업하겠습니다.

### 스크린샷 (선택)
<img width="2940" height="1594" alt="스크린샷 2026-02-08 오후 7 45 27" src="https://github.com/user-attachments/assets/49e1ccd5-49f2-4413-ac50-44aec94883b8" />
<img width="2940" height="1600" alt="스크린샷 2026-02-08 오후 7 46 33" src="https://github.com/user-attachments/assets/2755f23d-33c8-4fe7-a2ec-259e4c4a9742" />
<img width="2940" height="1614" alt="스크린샷 2026-02-08 오후 7 52 12" src="https://github.com/user-attachments/assets/6b9cdb32-9ca3-44fd-bbda-2c2999d5609b" />

